### PR TITLE
Corrected Array Dereference Issue

### DIFF
--- a/includes/ucf-events-common.php
+++ b/includes/ucf-events-common.php
@@ -30,13 +30,13 @@ if ( !class_exists( 'UCF_Events_Common' ) ) {
 			}
 		}
 	}
-
 }
-
 
 if ( !function_exists( 'ucf_events_display_classic_before' ) ) {
 
 	function ucf_events_display_classic_before( $items, $title, $display_type ) {
+		if ( ! is_array( $items ) ) { $items = array( $items ); }
+
 		ob_start();
 	?>
 		<div class="ucf-events ucf-events-classic">
@@ -51,6 +51,7 @@ if ( !function_exists( 'ucf_events_display_classic_before' ) ) {
 if ( !function_exists( 'ucf_events_display_classic_title' ) ) {
 
 	function ucf_events_display_classic_title( $items, $title, $display_type ) {
+		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		$formatted_title = $title;
 
 		switch ( $display_type ) {
@@ -73,6 +74,7 @@ if ( !function_exists( 'ucf_events_display_classic_title' ) ) {
 if ( !function_exists( 'ucf_events_display_classic' ) ) {
 
 	function ucf_events_display_classic( $items, $title ) {
+		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
 		<div class="ucf-events-list">
@@ -125,6 +127,7 @@ if ( !function_exists( 'ucf_events_display_classic' ) ) {
 if ( !function_exists( 'ucf_events_display_classic_after' ) ) {
 
 	function ucf_events_display_classic_after( $items, $title ) {
+		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
 		</div>

--- a/includes/ucf-events-common.php
+++ b/includes/ucf-events-common.php
@@ -35,8 +35,6 @@ if ( !class_exists( 'UCF_Events_Common' ) ) {
 if ( !function_exists( 'ucf_events_display_classic_before' ) ) {
 
 	function ucf_events_display_classic_before( $items, $title, $display_type ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
-
 		ob_start();
 	?>
 		<div class="ucf-events ucf-events-classic">
@@ -51,7 +49,6 @@ if ( !function_exists( 'ucf_events_display_classic_before' ) ) {
 if ( !function_exists( 'ucf_events_display_classic_title' ) ) {
 
 	function ucf_events_display_classic_title( $items, $title, $display_type ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		$formatted_title = $title;
 
 		switch ( $display_type ) {
@@ -127,7 +124,6 @@ if ( !function_exists( 'ucf_events_display_classic' ) ) {
 if ( !function_exists( 'ucf_events_display_classic_after' ) ) {
 
 	function ucf_events_display_classic_after( $items, $title ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
 		</div>


### PR DESCRIPTION
Corrects an issue where `do_action` dereferences the first item in a single index array, causing the variable passed to the callback to no longer be an array. Solves issue #2.