### PR TITLE
Whitelisting the default urls host.

### DIFF
--- a/includes/ucf-events-common.php
+++ b/includes/ucf-events-common.php
@@ -141,3 +141,17 @@ if ( ! function_exists( 'ucf_events_enqueue_assets' ) ) {
 
 	add_action( 'wp_enqueue_scripts', 'ucf_events_enqueue_assets' );
 }
+
+if ( ! function_exists( 'ucf_events_whitelist_host' ) ) {
+	function ucf_events_whitelist_host( $allow, $host, $url ) {
+		$default_url = UCF_Events_Config::get_option_or_default( 'feed_url' );
+		$default_host = parse_url( $default_url, PHP_URL_HOST );
+		if ( $default_host === $host ) {
+			$allow = true;
+		}
+
+		return $allow;
+	}
+
+	add_filter( 'http_request_host_is_external', 'ucf_events_whitelist_host', 10, 3 );
+}


### PR DESCRIPTION
Adds an additional function to allow external requests to the host that is configured in the `feed_url` configuration option, or it's default. This is required when making an external request using `wp_safe_remote_get`.

Alternatively, we could have used `wp_remote_get` which doesn't do the same level of url validation (and allows external requests by default). However, since we are allowing the url to be set via an option, it seemed to make sense to make sense to just "whitelist" it.