### PR TITLE
Shortcode return fix

### DIFF
--- a/includes/ucf-events-shortcode.php
+++ b/includes/ucf-events-shortcode.php
@@ -13,7 +13,12 @@ if ( !function_exists( 'sc_ucf_events' ) ) {
 		$atts = UCF_Events_Config::format_options( $atts );
 
 		$items = UCF_Events_Feed::get_events( $atts );
+
+		ob_start();
+
 		echo UCF_Events_Common::display_events( $items, $atts['layout'], $atts['title'], 'shortcode' );
+
+		return ob_get_clean(); // Shortcode must *return*!  Do not echo the result!
 	}
 	add_shortcode( 'ucf-events', 'sc_ucf_events' );
 

--- a/includes/ucf-events-widget.php
+++ b/includes/ucf-events-widget.php
@@ -37,7 +37,7 @@ if ( !class_exists( 'UCF_Events_Widget' ) ) {
 
 			echo $args['after_widget'];
 
-			echo ob_get_clean();
+			echo ob_get_clean(); // Widget must *echo*!  Do not return the result!
 		}
 
 		public function form( $instance ) {


### PR DESCRIPTION
Fixed the events shortcode to return a result instead of echo it.  Fixes output buffer issues where shortcode contents are displayed in the wrong location on the page (above the rest of the post content).

Added some comments to clarify and remind us (me) in the future when to echo vs return between shortcodes and widgets :)