### PR TITLE
Shortcode interface

### DIFF
--- a/includes/ucf-events-config.php
+++ b/includes/ucf-events-config.php
@@ -18,12 +18,30 @@ if ( !class_exists( 'UCF_Events_Config' ) ) {
 				'transient_expiration' => 3,  // hours
 			);
 
-		public static function get_layouts() {
+		/**
+		 * Gets the available layouts
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return Array
+		 **/
+		public static function get_layouts( $format='ARRAY' ) {
 			$layouts = array(
 				'classic' => 'Classic Layout',
 			);
 
 			$layouts = apply_filters( self::$option_prefix . 'get_layouts', $layouts );
+
+			if ( $format === 'ARRAY_A' ) {
+				$a_array = array();
+				foreach( $layouts as $value=>$label ) {
+					$a_array[] = array(
+						'label' => $label,
+						'value' => $value
+					);
+				}
+
+				return $a_array;
+			}
 
 			return $layouts;
 		}

--- a/includes/ucf-events-shortcode.php
+++ b/includes/ucf-events-shortcode.php
@@ -26,48 +26,59 @@ if ( !function_exists( 'sc_ucf_events' ) ) {
 
 if ( ! function_exists( 'ucf_events_shortcode_interface' ) ) {
 	function ucf_events_shortcode_interface( $shortcodes ) {
-		$settings = array(
-			'command' => 'ucf-events',
-			'name'    => 'UCF Event List',
-			'desc'    => 'Displays a list of events.',
-			'content' => false,
-			'fields'  => array(
-				array(
-					'param'    => 'title',
-					'name'     => 'Title',
-					'desc'     => 'The title to display above the events list.',
-					'type'     => 'text'
-				),
-				array(
-					'param'    => 'layout',
-					'name'     => 'Layout',
-					'desc'     => 'The layout used to display the events.',
-					'type'     => 'select',
-					'options'  => UCF_Events_Config::get_layouts()
-				),
-				array(
-					'param'    => 'feed_url',
-					'name'     => 'Feed URL',
-					'desc'     => 'The url to fetch the events from.',
-					'type'     => 'text'
-				),
-				array(
-					'param'    => 'limit',
-					'name'     => 'Limit',
-					'desc'     => 'The number of events to show.',
-					'type'     => 'text'
-				),
-				array(
-					'param'    => 'offset',
-					'name'     => 'Offset',
-					'desc'     => 'The number of events to skip.',
-					'type'     => 'text'
+		$fields = array(
+			array(
+				'label'       => 'Title',
+				'attr'        => 'title',
+				'description' => 'The title to display above the events list.',
+				'encode'      => false,
+				'type'        => 'text'
+			),
+			array(
+				'label'       => 'Layout',
+				'attr'        => 'layout',
+				'description' => 'The layout used to display the events.',
+				'type'        => 'select',
+				'options'     => UCF_Events_Config::get_layouts('ARRAY_A')
+			),
+			array(
+				'label'       => 'Feed URL',
+				'attr'        => 'feed_url',
+				'description' => 'The url to fetch the events from.',
+				'type'        => 'url',
+				'meta'        => array(
+					'placeholder' => 'https://events.ucf.edu/upcoming/feed.json'
 				)
+			),
+			array(
+				'label'       => 'Limit',
+				'attr'        => 'limit',
+				'description' => 'The number of events to display.',
+				'type'        => 'number'
+			),
+			array(
+				'label'       => 'Offset',
+				'attr'        => 'offset',
+				'description' => 'The number of events to skip.',
+				'type'        => 'number'
 			)
 		);
 
-		$shortcodes[] = $settings;
+		$args = array(
+			'label'         => 'UCF Event List',
+			'listItemImage' => 'dashicons-calendar',
+			'inner_content' => false,
+			'attrs'         => $fields
+		);
 
-		return $shortcodes;
+		shortcode_ui_register_for_shortcode( 'ucf-events', $args );
+	}
+}
+
+if ( ! function_exists( 'ucf_events_wysiwyg_styles' ) ) {
+	function ucf_events_wysiwyg_styles() {
+		if ( UCF_Events_Config::get_option_or_default( 'include_css' ) ) {
+			add_editor_style( plugins_url( 'static/css/ucf-events.min.css', UCF_EVENTS__PLUGIN_FILE ) );
+		}
 	}
 }

--- a/includes/ucf-events-shortcode.php
+++ b/includes/ucf-events-shortcode.php
@@ -24,58 +24,50 @@ if ( !function_exists( 'sc_ucf_events' ) ) {
 
 }
 
-
-if ( class_exists( 'UCF_Modular_Shortcode' ) && !class_exists( 'UCF_Events_Shortcode' ) ) {
-
-	class UCF_Events_Shortcode extends UCF_Modular_Shortcode {
-		public
-			$name        = 'UCF Events Feed',
-			$command     = 'ucf-events-feed',
-			$description = 'Displays a events feed pulled from events.ucf.edu';
-
-		function params() {
-			$layouts = UCF_Events_Config::get_layouts();
-			$defaults = UCF_Events_Config::get_option_defaults();
-
-			return array(
+if ( ! function_exists( 'ucf_events_shortcode_interface' ) ) {
+	function ucf_events_shortcode_interface( $shortcodes ) {
+		$settings = array(
+			'command' => 'ucf-events',
+			'name'    => 'UCF Event List',
+			'desc'    => 'Displays a list of events.',
+			'content' => false,
+			'fields'  => array(
 				array(
-					'name'      => 'Title',
-					'id'        => 'title',
-					'help_text' => 'The title to display before the events feed.',
-					'type'      => 'text',
-					'default'   => $defaults['title']
+					'param'    => 'title',
+					'name'     => 'Title',
+					'desc'     => 'The title to display above the events list.',
+					'type'     => 'text'
 				),
 				array(
-					'name'      => 'Feed URL',
-					'id'        => 'title',
-					'help_text' => 'The URL from which feed data will be fetched from events.ucf.edu. Defaults to the Feed URL set in the plugin options page.',
-					'type'      => 'text',
-					'default'   => $defaults['feed_url']
+					'param'    => 'layout',
+					'name'     => 'Layout',
+					'desc'     => 'The layout used to display the events.',
+					'type'     => 'select',
+					'options'  => UCF_Events_Config::get_layouts()
 				),
 				array(
-					'name'      => 'Layout',
-					'id'        => 'layout',
-					'help_text' => 'The layout to use to display the events items.',
-					'type'      => 'dropdown',
-					'choices'   => $layouts,
-					'default'   => $defaults['layout']
+					'param'    => 'feed_url',
+					'name'     => 'Feed URL',
+					'desc'     => 'The url to fetch the events from.',
+					'type'     => 'text'
 				),
 				array(
-					'name'      => 'Number of Events',
-					'id'        => 'limit',
-					'help_text' => 'The number of events to show.',
-					'type'      => 'number',
-					'default'   => $defaults['limit']
+					'param'    => 'limit',
+					'name'     => 'Limit',
+					'desc'     => 'The number of events to show.',
+					'type'     => 'text'
 				),
 				array(
-					'name'      => 'Offset Event Results',
-					'id'        => 'offset',
-					'help_text' => 'The number of event results that should be skipped. e.g., to skip the first event in the returned results, set the offset to "1".',
-					'type'      => 'number',
-					'default'   => $defaults['offset']
+					'param'    => 'offset',
+					'name'     => 'Offset',
+					'desc'     => 'The number of events to skip.',
+					'type'     => 'text'
 				)
-			);
-		}
-	}
+			)
+		);
 
+		$shortcodes[] = $settings;
+
+		return $shortcodes;
+	}
 }

--- a/ucf-events.php
+++ b/ucf-events.php
@@ -44,8 +44,9 @@ register_deactivation_hook( UCF_EVENTS__PLUGIN_FILE, 'ucf_events_plugin_deactiva
  **/
 add_action( 'plugins_loaded', function() {
 
-	if ( is_plugin_active( 'WP-Shortcode-Interface/wp-shortcode-interface.php' ) ) {
-		add_filter( 'wp_scif_add_shortcode', 'ucf_events_shortcode_interface', 10, 1 );
+	if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+		add_filter( 'init', 'ucf_events_shortcode_interface', 10, 1 );
+		add_action( 'admin_init', 'ucf_events_wysiwyg_styles', 10, 0 );
 	}
 
 } );

--- a/ucf-events.php
+++ b/ucf-events.php
@@ -44,9 +44,8 @@ register_deactivation_hook( UCF_EVENTS__PLUGIN_FILE, 'ucf_events_plugin_deactiva
  **/
 add_action( 'plugins_loaded', function() {
 
-	if ( class_exists( 'UCF_Modular_Shortcode' ) ) {
-		// TODO register shortcode interface class here
-		return;
+	if ( is_plugin_active( 'WP-Shortcode-Interface/wp-shortcode-interface.php' ) ) {
+		add_filter( 'wp_scif_add_shortcode', 'ucf_events_shortcode_interface', 10, 1 );
 	}
 
 } );


### PR DESCRIPTION
Enhancements:
* Replaces the logic for hooking into the WP-Shortcode-Interface plugin to using [Shortcake](https://github.com/wp-shortcake/Shortcake/).

## The new Interface Button

![screen shot 2017-05-26 at 10 00 26 am](https://cloud.githubusercontent.com/assets/1830748/26497718/766f6b66-41fa-11e7-93f6-a18174bb91aa.png)

## The list of available shortcodes

![screen shot 2017-05-26 at 10 00 45 am](https://cloud.githubusercontent.com/assets/1830748/26497733/84120fd0-41fa-11e7-94cb-0a79b34034c4.png)

## The shortcode form

![screen shot 2017-05-26 at 10 00 50 am](https://cloud.githubusercontent.com/assets/1830748/26497743/8dfa6592-41fa-11e7-9187-a15db27e2993.png)

## The WYSIWYG output

![screen shot 2017-05-26 at 10 01 01 am](https://cloud.githubusercontent.com/assets/1830748/26497748/951ce3c2-41fa-11e7-8239-95ae074c133c.png)



