### PR TITLE
Replace is_plugin_active() check with class_exists()

### DIFF
--- a/ucf-events.php
+++ b/ucf-events.php
@@ -47,7 +47,7 @@ register_deactivation_hook( UCF_EVENTS__PLUGIN_FILE, 'ucf_events_plugin_deactiva
  **/
 add_action( 'plugins_loaded', function() {
 
-	if ( is_plugin_active( 'WP-Shortcode-Interface/wp-shortcode-interface.php' ) ) {
+	if ( class_exists( 'WP_SCIF_Shortcode' ) ) {
 		add_filter( 'wp_scif_add_shortcode', 'ucf_events_shortcode_interface', 10, 1 );
 		add_filter( 'wp_scif_get_preview_stylesheets', 'ucf_events_shortcode_interface_styles', 10, 1 );
 	}


### PR DESCRIPTION
Replaces the check for whether or not the WP SCIF plugin is activated with a `class_exists()` check to avoid issues with `is_plugin_active()` bombing (likely due to `wp-admin/includes/plugin.php` not being loaded in).