### PR TITLE
Added null/false check to modern nodesc layout

### DIFF
--- a/layouts/ucf-events-modern.php
+++ b/layouts/ucf-events-modern.php
@@ -126,7 +126,7 @@ add_filter( 'ucf_events_display_modern_nodesc_title', 'ucf_events_display_modern
 if ( !function_exists( 'ucf_events_display_modern_nodesc' ) ) {
 
 	function ucf_events_display_modern_nodesc( $content, $items, $args, $display_type, $fallback_message='' ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
+		if ( $items && ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
 		<div class="ucf-events-list">


### PR DESCRIPTION
When the modern_nodesc layout tries to process the `$items` variable when it's false, the lack of a check on the variable results in `$items = array( false );` which is then passed to the foreach loop. I think this is what was causing the 500 error to occur while events was inaccessible.