### PR TITLE
Improved PHP 7.2 Compatibility & Setting Usability

### DIFF
--- a/includes/ucf-events-config.php
+++ b/includes/ucf-events-config.php
@@ -274,7 +274,7 @@ if ( !class_exists( 'UCF_Events_Config' ) ) {
 				default:
 					ob_start();
 				?>
-					<input type="text" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_value; ?>">
+					<input type="text" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_value; ?>" class="large-text">
 					<p class="description">
 						<?php echo $description; ?>
 					</p>

--- a/includes/ucf-events-widget.php
+++ b/includes/ucf-events-widget.php
@@ -81,7 +81,7 @@ if ( !class_exists( 'UCF_Events_Widget' ) ) {
 	}
 
 	add_action( 'widgets_init',
-		create_function( '', 'return register_widget( "UCF_Events_Widget" );' )
+		function(){ return register_widget( "UCF_Events_Widget" ); }
 	);
 
 }

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,10 @@ This plugin provides a shortcode, widget, helper functions, and default styles f
 
 
 ## Changelog ##
+### 2.1.4 ###
+* Bug Fixes:
+  * Improved compatibility with PHP 7.2 due to deprecation of create_function()
+  * Updated Events JSON Feed URL input box to expand the full width of the screen using a built in WP class for better usability
 
 ### 2.1.3 ###
 * Bug Fixes:

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,10 @@ This plugin provides a shortcode, widget, helper functions, and default styles f
 
 
 == Changelog ==
+= 2.1.4 =
+* Bug Fixes:
+  * Improved compatibility with PHP 7.2 due to deprecation of create_function()
+  * Updated Events JSON Feed URL input box to expand the full width of the screen using a built in WP class for better usability
 
 = 2.1.3 =
 * Bug Fixes:

--- a/ucf-events.php
+++ b/ucf-events.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: UCF Events
 Description: Contains shortcode and widget for displaying UCF Events Feeds
-Version: 2.1.3
+Version: 2.1.4
 Author: UCF Web Communications
 License: GPL3
 Github Plugin URI: UCF/UCF-Events-Plugin


### PR DESCRIPTION
PHP 7.2 deprecated create_function() and it was causing the plugin to throw a warning. I changed create_function() to function(){}. Additionally I updated the Events JSON Feed URL input box to expand the full width of the screen using a built in WP class for better usability. The default text box size was not wide enough to show the full feed URL.